### PR TITLE
Added rest-client example to replace the need for postman.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["esbenp.prettier-vscode", "humao.rest-client"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,10 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.bracketPairColorization.enabled": true,
     "editor.formatOnSave": true,
-    "editor.formatOnPaste": true
+    "editor.formatOnPaste": true,
+    "rest-client.environmentVariables": {
+        "local": {
+            "API_HOST": "http://localhost:1337"
+        }
+    }
 }

--- a/rest/main.rest
+++ b/rest/main.rest
@@ -1,0 +1,5 @@
+### Options
+OPTIONS {{API_HOST}}
+
+### Healthcheck
+GET {{API_HOST}}/main/healthcheck


### PR DESCRIPTION
Great tutorial. 

In case you are interested, I've added this example as a productivity tip that removes the need for Postman. I've worked in a few teams where the infamous "Postman collection" is somewhat challenging to pin down. VSCode has an awesome plugin called Rest Client. It allows you to do everything Postman does but it keeps the code with the repository which I find really beneficial, not to mention simple, for teams to use (even if that team is myself).

I've added a couple of things to this PR:

1. Added `.vscode/extensions.json` - prompts the user to installed the plugins that you intend them to use.
2. Added `rest-client.environmentVariables` to `.vscode/settings.json`- this sets up an example environment for Rest Client to use. This also allows you to commit known properties that would easily allow you to switch between local and other deployed environments. Just make sure `local` is selected on the bottom status bar of VSCode (it should be after the Language Mode selector).
3. Added `rest/main.rest` - documents all the end-points you should be able to hit (without having to fight with any other application).

Maybe this can inspire some content for a future episode.

<img width="1246" alt="Screenshot 2024-02-27 at 3 09 03 PM" src="https://github.com/joeythelantern/api-basic/assets/700871/72c615e7-e08c-4729-a4e5-042602ff8619">
